### PR TITLE
Feature/cadastro de exame

### DIFF
--- a/src/features/admin/api/parseApiError.ts
+++ b/src/features/admin/api/parseApiError.ts
@@ -1,38 +1,9 @@
-type ParsedApiError = {
-  message: string;
-  fieldErrors: Record<string, string>;
-};
+import {
+  parseApiError as parseSharedApiError,
+  type ParsedApiError,
+} from '@/shared/parseApiError';
 
-export const parseApiError = (errorBody: unknown): ParsedApiError => {
-  if (!errorBody || typeof errorBody !== 'object') {
-    return {
-      message: 'Não foi possível cadastrar o usuário.',
-      fieldErrors: {},
-    };
-  }
+const DEFAULT_MESSAGE = 'Não foi possível cadastrar o usuário.';
 
-  const body = errorBody as {
-    message?: string;
-    errors?: Record<string, string[] | undefined>;
-  };
-
-  const fieldErrors: Record<string, string> = {};
-
-  if (body.errors) {
-    for (const [field, messages] of Object.entries(body.errors)) {
-      if (messages?.length) {
-        fieldErrors[field] = messages[0];
-      }
-    }
-  }
-
-  const firstFieldError = Object.values(fieldErrors)[0];
-
-  return {
-    message:
-      firstFieldError ||
-      body.message ||
-      'Não foi possível cadastrar o usuário.',
-    fieldErrors,
-  };
-};
+export const parseApiError = (errorBody: unknown): ParsedApiError =>
+  parseSharedApiError(errorBody, DEFAULT_MESSAGE);

--- a/src/features/exames/api/createExam.ts
+++ b/src/features/exames/api/createExam.ts
@@ -1,0 +1,8 @@
+import { api } from '@/shared/api';
+import type { CreateExamDTO } from '../types/exam';
+
+export async function createExam(data: CreateExamDTO) {
+  const response = await api.post('/api/exams', data);
+
+  return response.data;
+}

--- a/src/features/exames/api/parseApiError.ts
+++ b/src/features/exames/api/parseApiError.ts
@@ -1,35 +1,9 @@
-type ParsedApiError = {
-  message: string;
-  fieldErrors: Record<string, string>;
-};
+import {
+  parseApiError as parseSharedApiError,
+  type ParsedApiError,
+} from '@/shared/parseApiError';
 
-export const parseApiError = (errorBody: unknown): ParsedApiError => {
-  if (!errorBody || typeof errorBody !== 'object') {
-    return {
-      message: 'Nao foi possivel criar o exame.',
-      fieldErrors: {},
-    };
-  }
+const DEFAULT_MESSAGE = 'Nao foi possivel criar o exame.';
 
-  const body = errorBody as {
-    message?: string;
-    errors?: Record<string, string[] | undefined>;
-  };
-
-  const fieldErrors: Record<string, string> = {};
-
-  if (body.errors) {
-    for (const [field, messages] of Object.entries(body.errors)) {
-      if (messages?.length) {
-        fieldErrors[field] = messages[0];
-      }
-    }
-  }
-
-  const firstFieldError = Object.values(fieldErrors)[0];
-
-  return {
-    message: firstFieldError || body.message || 'Nao foi possivel criar o exame.',
-    fieldErrors,
-  };
-};
+export const parseApiError = (errorBody: unknown): ParsedApiError =>
+  parseSharedApiError(errorBody, DEFAULT_MESSAGE);

--- a/src/features/exames/api/parseApiError.ts
+++ b/src/features/exames/api/parseApiError.ts
@@ -1,0 +1,35 @@
+type ParsedApiError = {
+  message: string;
+  fieldErrors: Record<string, string>;
+};
+
+export const parseApiError = (errorBody: unknown): ParsedApiError => {
+  if (!errorBody || typeof errorBody !== 'object') {
+    return {
+      message: 'Nao foi possivel criar o exame.',
+      fieldErrors: {},
+    };
+  }
+
+  const body = errorBody as {
+    message?: string;
+    errors?: Record<string, string[] | undefined>;
+  };
+
+  const fieldErrors: Record<string, string> = {};
+
+  if (body.errors) {
+    for (const [field, messages] of Object.entries(body.errors)) {
+      if (messages?.length) {
+        fieldErrors[field] = messages[0];
+      }
+    }
+  }
+
+  const firstFieldError = Object.values(fieldErrors)[0];
+
+  return {
+    message: firstFieldError || body.message || 'Nao foi possivel criar o exame.',
+    fieldErrors,
+  };
+};

--- a/src/features/exames/hooks/useCreateExam.ts
+++ b/src/features/exames/hooks/useCreateExam.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { createExam } from '../api/createExam';
+
+export function useCreateExam() {
+  return useMutation({
+    mutationFn: createExam,
+  });
+}

--- a/src/features/exames/routes/NovoExame.tsx
+++ b/src/features/exames/routes/NovoExame.tsx
@@ -1,5 +1,129 @@
+import { Button } from '@/components/ui/button';
+import { useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+
+const formatCpf = (value: string): string => {
+  const digits = value.replace(/\D/g, '').slice(0, 11);
+
+  return digits
+    .replace(/(\d{3})(\d)/, '$1.$2')
+    .replace(/(\d{3})(\d)/, '$1.$2')
+    .replace(/(\d{3})(\d{1,2})$/, '$1-$2');
+};
+
 const NovoExame = () => {
-  return <div>NovoExame</div>;
+  const [nomeCompleto, setNomeCompleto] = useState('');
+  const [dataNascimento, setDataNascimento] = useState('');
+  const [sexo, setSexo] = useState('');
+  const [cpf, setCpf] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  return (
+    <div className="min-h-screen px-6 py-8 sm:px-10 lg:px-12">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+        <header className="text-center">
+          <h2 className="text-4xl font-heading font-bold text-foreground sm:text-2xl">
+            Novo Exame
+          </h2>
+
+          <p className="text-md text-muted-foreground">
+            Preencha os dados do paciente abaixo.
+          </p>
+        </header>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Card className="p-4">
+            <label className="text-sm font-bold">Nome do Paciente</label>
+            <Input
+              onChange={(e) => setNomeCompleto(e.target.value)}
+              placeholder="Digite o nome completo do paciente"
+              value={nomeCompleto}
+              required
+            />
+          </Card>
+
+          <Card className="p-4">
+            <label className="text-sm font-semibold">Data de nascimento</label>
+            <Input
+              type="date"
+              value={dataNascimento}
+              onChange={(e) => setDataNascimento(e.target.value)}
+              className={
+                dataNascimento ? 'text-foreground' : 'text-muted-foreground'
+              }
+              required
+            />
+          </Card>
+        </div>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Card className="p-4">
+            <label className="text-sm font-semibold">Sexo</label>
+            <select
+              value={sexo}
+              onChange={(e) => setSexo(e.target.value)}
+              className={`h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 ${sexo ? 'text-foreground' : 'text-muted-foreground'}`}
+              required
+            >
+              <option value="" disabled>
+                Selecione o sexo
+              </option>
+              <option value="feminino">Feminino</option>
+              <option value="masculino">Masculino</option>
+            </select>
+          </Card>
+
+          <Card className="p-4">
+            <label className="text-sm font-semibold">CPF</label>
+            <Input
+              type="text"
+              placeholder="000.000.000-00"
+              value={cpf}
+              onChange={(e) => {
+                setCpf(formatCpf(e.target.value));
+                setFieldErrors((prev) => {
+                  const next = { ...prev };
+                  delete next.cpf;
+                  return next;
+                });
+              }}
+              required
+            />
+            {fieldErrors.cpf && (
+              <p className="text-xs text-destructive">{fieldErrors.cpf}</p>
+            )}
+          </Card>
+        </div>
+        <Card className="p-4">
+          <label className="text-sm font-semibold">Prontuário</label>
+          <textarea
+            className="w-full min-h-32 rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+            placeholder="Digite o prontuário do paciente"
+            rows={4}
+            required
+          />
+        </Card>
+
+        <Card className="p-4">
+          <label className="text-sm font-semibold">Comorbidades</label>
+          <textarea
+            className="w-full min-h-32 rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+            placeholder="Descreva as comorbidades"
+            rows={4}
+            required
+          />
+        </Card>
+
+        <Button
+          type="submit"
+          size="sm"
+          className="self-center border-0 px-10 py-4 text-primary-foreground font-semibold hover:opacity-90"
+        >
+          Continuar
+        </Button>
+      </div>
+    </div>
+  );
 };
 
 export default NovoExame;

--- a/src/features/exames/routes/NovoExame.tsx
+++ b/src/features/exames/routes/NovoExame.tsx
@@ -2,6 +2,11 @@ import { Button } from '@/components/ui/button';
 import { useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { useCreateExam } from '../hooks/useCreateExam';
+import { parseApiError } from '../api/parseApiError';
+import { toast } from 'sonner';
+import { useNavigate } from 'react-router';
+import type { SexoExame } from '../types/exam';
 
 const formatCpf = (value: string): string => {
   const digits = value.replace(/\D/g, '').slice(0, 11);
@@ -15,13 +20,63 @@ const formatCpf = (value: string): string => {
 const NovoExame = () => {
   const [nomeCompleto, setNomeCompleto] = useState('');
   const [dataNascimento, setDataNascimento] = useState('');
-  const [sexo, setSexo] = useState('');
+  const [sexo, setSexo] = useState<SexoExame | ''>('');
   const [cpf, setCpf] = useState('');
+  const [comorbidades, setComorbidades] = useState('');
+  const [descricao, setDescricao] = useState('');
+  const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  const navigate = useNavigate();
+  const createExamMutation = useCreateExam();
+
+  const resetForm = () => {
+    setNomeCompleto('');
+    setDataNascimento('');
+    setSexo('');
+    setCpf('');
+    setComorbidades('');
+    setDescricao('');
+    setError(null);
+    setFieldErrors({});
+  };
+
+  const handleCreateExam = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    setError(null);
+    setFieldErrors({});
+
+    try {
+      await createExamMutation.mutateAsync({
+        nomeCompleto,
+        cpf: cpf.replace(/\D/g, ''),
+        sexo: sexo as SexoExame,
+        dtNascimento: dataNascimento,
+        dtHora: new Date().toISOString(),
+        comorbidades: comorbidades.trim() ? comorbidades : undefined,
+        descricao: descricao.trim() ? descricao : undefined,
+      });
+
+      toast.success('Exame criado com sucesso.');
+      resetForm();
+      navigate('/exames');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      const { message, fieldErrors } = parseApiError(err?.response?.data);
+
+      setError(message);
+      setFieldErrors(fieldErrors);
+      toast.error(message);
+    }
+  };
 
   return (
     <div className="min-h-screen px-6 py-8 sm:px-10 lg:px-12">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+      <form
+        className="mx-auto flex w-full max-w-6xl flex-col gap-6"
+        onSubmit={handleCreateExam}
+      >
         <header className="text-center">
           <h2 className="text-4xl font-heading font-bold text-foreground sm:text-2xl">
             Novo Exame
@@ -36,11 +91,21 @@ const NovoExame = () => {
           <Card className="p-4">
             <label className="text-sm font-bold">Nome do Paciente</label>
             <Input
-              onChange={(e) => setNomeCompleto(e.target.value)}
+              onChange={(e) => {
+                setNomeCompleto(e.target.value);
+                setFieldErrors((prev) => {
+                  const next = { ...prev };
+                  delete next.nomeCompleto;
+                  return next;
+                });
+              }}
               placeholder="Digite o nome completo do paciente"
               value={nomeCompleto}
               required
             />
+            {fieldErrors.nomeCompleto && (
+              <p className="text-xs text-destructive">{fieldErrors.nomeCompleto}</p>
+            )}
           </Card>
 
           <Card className="p-4">
@@ -48,12 +113,22 @@ const NovoExame = () => {
             <Input
               type="date"
               value={dataNascimento}
-              onChange={(e) => setDataNascimento(e.target.value)}
+              onChange={(e) => {
+                setDataNascimento(e.target.value);
+                setFieldErrors((prev) => {
+                  const next = { ...prev };
+                  delete next.dtNascimento;
+                  return next;
+                });
+              }}
               className={
                 dataNascimento ? 'text-foreground' : 'text-muted-foreground'
               }
               required
             />
+            {fieldErrors.dtNascimento && (
+              <p className="text-xs text-destructive">{fieldErrors.dtNascimento}</p>
+            )}
           </Card>
         </div>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -61,16 +136,27 @@ const NovoExame = () => {
             <label className="text-sm font-semibold">Sexo</label>
             <select
               value={sexo}
-              onChange={(e) => setSexo(e.target.value)}
+              onChange={(e) => {
+                setSexo(e.target.value as SexoExame);
+                setFieldErrors((prev) => {
+                  const next = { ...prev };
+                  delete next.sexo;
+                  return next;
+                });
+              }}
               className={`h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 ${sexo ? 'text-foreground' : 'text-muted-foreground'}`}
               required
             >
               <option value="" disabled>
                 Selecione o sexo
               </option>
-              <option value="feminino">Feminino</option>
-              <option value="masculino">Masculino</option>
+              <option value="FEMININO">Feminino</option>
+              <option value="MASCULINO">Masculino</option>
+              <option value="OUTRO">Outro</option>
             </select>
+            {fieldErrors.sexo && (
+              <p className="text-xs text-destructive">{fieldErrors.sexo}</p>
+            )}
           </Card>
 
           <Card className="p-4">
@@ -95,33 +181,59 @@ const NovoExame = () => {
           </Card>
         </div>
         <Card className="p-4">
-          <label className="text-sm font-semibold">Prontuário</label>
-          <textarea
-            className="w-full min-h-32 rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
-            placeholder="Digite o prontuário do paciente"
-            rows={4}
-            required
-          />
-        </Card>
-
-        <Card className="p-4">
           <label className="text-sm font-semibold">Comorbidades</label>
           <textarea
             className="w-full min-h-32 rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
-            placeholder="Descreva as comorbidades"
+            placeholder="Descreva as comorbidades do paciente, se houver"
             rows={4}
+            value={comorbidades}
+            onChange={(e) => {
+              setComorbidades(e.target.value);
+              setFieldErrors((prev) => {
+                const next = { ...prev };
+                delete next.comorbidades;
+                return next;
+              });
+            }}
+          />
+          {fieldErrors.comorbidades && (
+            <p className="text-xs text-destructive">{fieldErrors.comorbidades}</p>
+          )}
+        </Card>
+        <Card className="p-4">
+          <label className="text-sm font-semibold">Descrição</label>
+          <textarea
+            className="w-full min-h-32 rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+            placeholder="Dê uma descrição sobre o motivo do exame"
+            rows={4}
+            value={descricao}
+            onChange={(e) => {
+              setDescricao(e.target.value);
+              setFieldErrors((prev) => {
+                const next = { ...prev };
+                delete next.descricao;
+                return next;
+              });
+            }}
             required
           />
+          {fieldErrors.descricao && (
+            <p className="text-xs text-destructive">{fieldErrors.descricao}</p>
+          )}
         </Card>
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+
 
         <Button
           type="submit"
           size="sm"
+          disabled={createExamMutation.isPending}
           className="self-center border-0 px-10 py-4 text-primary-foreground font-semibold hover:opacity-90"
         >
-          Continuar
+          {createExamMutation.isPending ? 'Salvando...' : 'Continuar'}
         </Button>
-      </div>
+      </form>
     </div>
   );
 };

--- a/src/features/exames/routes/NovoExame.tsx
+++ b/src/features/exames/routes/NovoExame.tsx
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router';
 import type { SexoExame } from '../types/exam';
 
 const formatCpf = (value: string): string => {
-  const digits = value.replace(/\D/g, '').slice(0, 11);
+  const digits = value.replaceAll(/\D/g, '').slice(0, 11);
 
   return digits
     .replace(/(\d{3})(\d)/, '$1.$2')
@@ -50,7 +50,7 @@ const NovoExame = () => {
     try {
       await createExamMutation.mutateAsync({
         nomeCompleto,
-        cpf: cpf.replace(/\D/g, ''),
+        cpf: cpf.replaceAll(/\D/g, ''),
         sexo: sexo as SexoExame,
         dtNascimento: dataNascimento,
         dtHora: new Date().toISOString(),
@@ -89,8 +89,11 @@ const NovoExame = () => {
 
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <Card className="p-4">
-            <label className="text-sm font-bold">Nome do Paciente</label>
+            <label htmlFor="nomeCompleto" className="text-sm font-bold">
+              Nome do Paciente
+            </label>
             <Input
+              id="nomeCompleto"
               onChange={(e) => {
                 setNomeCompleto(e.target.value);
                 setFieldErrors((prev) => {
@@ -109,8 +112,11 @@ const NovoExame = () => {
           </Card>
 
           <Card className="p-4">
-            <label className="text-sm font-semibold">Data de nascimento</label>
+            <label htmlFor="dtNascimento" className="text-sm font-semibold">
+              Data de nascimento
+            </label>
             <Input
+              id="dtNascimento"
               type="date"
               value={dataNascimento}
               onChange={(e) => {
@@ -133,8 +139,11 @@ const NovoExame = () => {
         </div>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <Card className="p-4">
-            <label className="text-sm font-semibold">Sexo</label>
+            <label htmlFor="sexo" className="text-sm font-semibold">
+              Sexo
+            </label>
             <select
+              id="sexo"
               value={sexo}
               onChange={(e) => {
                 setSexo(e.target.value as SexoExame);
@@ -160,8 +169,11 @@ const NovoExame = () => {
           </Card>
 
           <Card className="p-4">
-            <label className="text-sm font-semibold">CPF</label>
+            <label htmlFor="cpf" className="text-sm font-semibold">
+              CPF
+            </label>
             <Input
+              id="cpf"
               type="text"
               placeholder="000.000.000-00"
               value={cpf}
@@ -181,8 +193,11 @@ const NovoExame = () => {
           </Card>
         </div>
         <Card className="p-4">
-          <label className="text-sm font-semibold">Comorbidades</label>
+          <label htmlFor="comorbidades" className="text-sm font-semibold">
+            Comorbidades
+          </label>
           <textarea
+            id="comorbidades"
             className="w-full min-h-32 rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
             placeholder="Descreva as comorbidades do paciente, se houver"
             rows={4}
@@ -201,8 +216,11 @@ const NovoExame = () => {
           )}
         </Card>
         <Card className="p-4">
-          <label className="text-sm font-semibold">Descrição</label>
+          <label htmlFor="descricao" className="text-sm font-semibold">
+            Descrição
+          </label>
           <textarea
+            id="descricao"
             className="w-full min-h-32 rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
             placeholder="Dê uma descrição sobre o motivo do exame"
             rows={4}

--- a/src/features/exames/types/exam.ts
+++ b/src/features/exames/types/exam.ts
@@ -1,0 +1,11 @@
+export type SexoExame = 'MASCULINO' | 'FEMININO' | 'OUTRO';
+
+export type CreateExamDTO = {
+  nomeCompleto: string;
+  cpf: string;
+  sexo: SexoExame;
+  dtNascimento: string;
+  dtHora: string;
+  comorbidades?: string;
+  descricao?: string;
+};

--- a/src/shared/parseApiError.ts
+++ b/src/shared/parseApiError.ts
@@ -1,0 +1,39 @@
+export type ParsedApiError = {
+  message: string;
+  fieldErrors: Record<string, string>;
+};
+
+type ErrorBody = {
+  message?: string;
+  errors?: Record<string, string[] | undefined>;
+};
+
+export const parseApiError = (
+  errorBody: unknown,
+  defaultMessage: string,
+): ParsedApiError => {
+  if (!errorBody || typeof errorBody !== 'object') {
+    return {
+      message: defaultMessage,
+      fieldErrors: {},
+    };
+  }
+
+  const body = errorBody as ErrorBody;
+  const fieldErrors: Record<string, string> = {};
+
+  if (body.errors) {
+    for (const [field, messages] of Object.entries(body.errors)) {
+      if (messages?.length) {
+        fieldErrors[field] = messages[0];
+      }
+    }
+  }
+
+  const firstFieldError = Object.values(fieldErrors)[0];
+
+  return {
+    message: firstFieldError || body.message || defaultMessage,
+    fieldErrors,
+  };
+};

--- a/src/test/features/exames/api/createExam.test.ts
+++ b/src/test/features/exames/api/createExam.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { api } from '@/shared/api';
+import { createExam } from '@/features/exames/api/createExam';
+
+vi.mock('@/shared/api', () => ({
+  api: {
+    post: vi.fn(),
+  },
+}));
+
+describe('createExam', () => {
+  const mockData = {
+    nomeCompleto: 'Maria da Silva',
+    cpf: '12345678901',
+    sexo: 'FEMININO',
+    dtNascimento: '1990-01-15',
+    dtHora: '2026-04-24T12:00:00.000Z',
+    comorbidades: 'Hipertensao',
+    descricao: 'Visao turva',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('deve chamar a API com os parametros corretos e retornar os dados', async () => {
+    const mockResponse = { data: { id: 'exam-1', ...mockData } };
+    vi.mocked(api.post).mockResolvedValueOnce(mockResponse);
+
+    const result = await createExam(mockData as any);
+
+    expect(api.post).toHaveBeenCalledWith('/api/exams', mockData);
+    expect(api.post).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(mockResponse.data);
+  });
+
+  it('deve propagar o erro quando a chamada da API falha', async () => {
+    vi.mocked(api.post).mockRejectedValueOnce(new Error('Erro ao criar exame'));
+
+    await expect(createExam(mockData as any)).rejects.toThrow(
+      'Erro ao criar exame'
+    );
+  });
+});

--- a/src/test/features/exames/api/parseApiError.test.ts
+++ b/src/test/features/exames/api/parseApiError.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { parseApiError } from '@/features/exames/api/parseApiError';
+
+describe('parseApiError (exames)', () => {
+  it('retorna mensagem padrao quando corpo e invalido', () => {
+    expect(parseApiError(null)).toEqual({
+      message: 'Nao foi possivel criar o exame.',
+      fieldErrors: {},
+    });
+  });
+
+  it('prioriza erro de campo quando existir', () => {
+    const result = parseApiError({
+      message: 'Falha generica.',
+      errors: {
+        cpf: ['CPF invalido.'],
+      },
+    });
+
+    expect(result).toEqual({
+      message: 'CPF invalido.',
+      fieldErrors: {
+        cpf: 'CPF invalido.',
+      },
+    });
+  });
+
+  it('usa a mensagem da API quando nao ha erro de campo', () => {
+    const result = parseApiError({
+      message: 'Erro ao criar exame.',
+    });
+
+    expect(result).toEqual({
+      message: 'Erro ao criar exame.',
+      fieldErrors: {},
+    });
+  });
+});

--- a/src/test/features/exames/hooks/useCreateExam.test.ts
+++ b/src/test/features/exames/hooks/useCreateExam.test.ts
@@ -1,0 +1,59 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createExam } from '@/features/exames/api/createExam';
+import { useCreateExam } from '@/features/exames/hooks/useCreateExam';
+
+vi.mock('@/features/exames/api/createExam', () => ({
+  createExam: vi.fn(),
+}));
+
+describe('useCreateExam', () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    vi.clearAllMocks();
+  });
+
+  it('deve chamar createExam e concluir com sucesso', async () => {
+    const examData = {
+      nomeCompleto: 'Joao Santos',
+      cpf: '12345678901',
+      sexo: 'MASCULINO',
+      dtNascimento: '1985-09-21',
+      dtHora: '2026-04-24T12:00:00.000Z',
+      descricao: 'Checkup',
+    };
+
+    vi.mocked(createExam).mockResolvedValue({ id: 'exam-1', ...examData } as any);
+
+    const { result } = renderHook(() => useCreateExam(), { wrapper });
+
+    result.current.mutate(examData as any);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(vi.mocked(createExam).mock.calls[0][0]).toEqual(examData);
+  });
+
+  it('deve retornar erro quando a mutacao falha', async () => {
+    vi.mocked(createExam).mockRejectedValue(new Error('Falha na API'));
+
+    const { result } = renderHook(() => useCreateExam(), { wrapper });
+
+    result.current.mutate({} as any);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});

--- a/src/test/features/exames/routes/NovoExame.test.tsx
+++ b/src/test/features/exames/routes/NovoExame.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import NovoExame from '@/features/exames/routes/NovoExame';
+import { useCreateExam } from '@/features/exames/hooks/useCreateExam';
+import { toast } from 'sonner';
+
+const mocks = vi.hoisted(() => ({
+  mutateAsync: vi.fn(),
+  navigate: vi.fn(),
+}));
+
+vi.mock('@/features/exames/hooks/useCreateExam', () => ({
+  useCreateExam: vi.fn(),
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+  };
+});
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('NovoExame', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useCreateExam).mockReturnValue({
+      mutateAsync: mocks.mutateAsync,
+      isPending: false,
+    } as any);
+  });
+
+  it('envia o formulario com payload correto e redireciona no sucesso', async () => {
+    const user = userEvent.setup();
+
+    mocks.mutateAsync.mockResolvedValue({ id: 'exam-1' });
+
+    render(<NovoExame />);
+
+    await user.type(
+      screen.getByPlaceholderText('Digite o nome completo do paciente'),
+      'Maria da Silva'
+    );
+    const birthDateInput = document.querySelector('input[type="date"]');
+
+    expect(birthDateInput).toBeTruthy();
+    fireEvent.change(birthDateInput!, { target: { value: '1990-01-15' } });
+    await user.selectOptions(screen.getByRole('combobox'), 'FEMININO');
+    await user.type(screen.getByPlaceholderText('000.000.000-00'), '12345678901');
+    await user.type(
+      screen.getByPlaceholderText(/comorbidades/i),
+      'Hipertensao'
+    );
+    await user.type(
+      screen.getByPlaceholderText(/motivo do exame/i),
+      'Paciente com visao turva'
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Continuar' }));
+
+    await waitFor(() => {
+      expect(mocks.mutateAsync).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = mocks.mutateAsync.mock.calls[0][0];
+
+    expect(payload).toEqual({
+      nomeCompleto: 'Maria da Silva',
+      cpf: '12345678901',
+      sexo: 'FEMININO',
+      dtNascimento: '1990-01-15',
+      dtHora: expect.any(String),
+      comorbidades: 'Hipertensao',
+      descricao: 'Paciente com visao turva',
+    });
+    expect(new Date(payload.dtHora).toString()).not.toBe('Invalid Date');
+
+    expect(toast.success).toHaveBeenCalledWith('Exame criado com sucesso.');
+    expect(mocks.navigate).toHaveBeenCalledWith('/exames');
+  });
+
+  it('mostra erro quando a API falha', async () => {
+    const user = userEvent.setup();
+
+    mocks.mutateAsync.mockRejectedValue({
+      response: {
+        data: {
+          message: 'Erro ao criar exame.',
+          errors: {
+            cpf: ['CPF invalido.'],
+          },
+        },
+      },
+    });
+
+    render(<NovoExame />);
+
+    await user.type(
+      screen.getByPlaceholderText('Digite o nome completo do paciente'),
+      'Joao Santos'
+    );
+    const birthDateInput = document.querySelector('input[type="date"]');
+
+    expect(birthDateInput).toBeTruthy();
+    fireEvent.change(birthDateInput!, { target: { value: '1985-09-21' } });
+    await user.selectOptions(screen.getByRole('combobox'), 'MASCULINO');
+    await user.type(screen.getByPlaceholderText('000.000.000-00'), '12345678901');
+    await user.type(
+      screen.getByPlaceholderText(/motivo do exame/i),
+      'Checkup'
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Continuar' }));
+
+    const cpfErrors = await screen.findAllByText('CPF invalido.');
+
+    expect(cpfErrors.length).toBeGreaterThan(0);
+    expect(toast.error).toHaveBeenCalledWith('CPF invalido.');
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it('desabilita o botao quando mutation esta pendente', () => {
+    vi.mocked(useCreateExam).mockReturnValue({
+      mutateAsync: mocks.mutateAsync,
+      isPending: true,
+    } as any);
+
+    render(<NovoExame />);
+
+    expect(screen.getByRole('button', { name: 'Salvando...' })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
Cadastro de Exame - front-end

## Descrição
Implementa o fluxo de cadastro de exame no front-end com integração ao backend, incluindo envio do formulário, tratamento de erros da API, feedback visual para sucesso e falha, e cobertura com testes unitários.

## Issue
(https://github.com/fga-eps-mds/2026-1-RetinaScan-Web/issues/9)

## Principais Implementações
  Criação da camada de API para cadastro de exame.
  Implementação de hook de mutation para envio do exame.
  Integração da tela de Novo Exame com o backend.
  Ajustes no formulário:
  Normalização de CPF para envio sem máscara.
  Mapeamento de sexo para os valores esperados pela API.
  Envio automático de data e hora do cadastro.
  Exibição de erros por campo e mensagem geral.
  Toast de sucesso e erro.
  Estado de carregamento e desabilitação do botão durante envio.
  Redirecionamento após sucesso no cadastro.
  Inclusão de testes unitários
  
## Tipos de Mudanças
 - [x] Bug fix (alteração que corrige uma issue e não altera funcionalidades já existentes);
 - [x] Nova feature (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes);
 - [ ] Alteração disruptiva (Breaking change) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes);
 - [ ] Documentação