### PR TITLE
Feature/interpretacao dicom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "better-auth": "^1.6.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "dicom-parser": "^1.8.21",
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.7.0",
         "next-themes": "^0.4.6",
@@ -5662,6 +5663,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/dicom-parser": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/dicom-parser/-/dicom-parser-1.8.21.tgz",
+      "integrity": "sha512-lYCweHQDsC8UFpXErPlg86Px2A8bay0HiUY+wzoG3xv5GzgqVHU3lziwSc/Gzn7VV7y2KeP072SzCviuOoU02w==",
       "license": "MIT"
     },
     "node_modules/diff": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "better-auth": "^1.6.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dicom-parser": "^1.8.21",
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.7.0",
     "next-themes": "^0.4.6",

--- a/src/test/utils/dicom/mapDicomToForm.test.ts
+++ b/src/test/utils/dicom/mapDicomToForm.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { mapDicomToExamForm } from '@/utils/dicom/mapDicomToForm';
+import type { ExtractedDicomData } from '@/utils/dicom/dicom.types';
+
+describe('Utilitário DICOM - mapDicomToExamForm', () => {
+  
+  it('Deve formatar os dados básicos corretamente (Datas, Hora e Sexo)', () => {
+    const mockData = {
+      patientSex: 'M',
+      patientBirthDate: '19980521',
+      seriesDate: '20260511',
+      seriesTime: '143522', 
+      patientComments: null
+    } as ExtractedDicomData;
+
+    const result = mapDicomToExamForm(mockData);
+
+    expect(result.sexo).toBe('MASCULINO');
+    expect(result.dtNascimento).toBe('21-05-1998');
+    expect(result.dtHora).toBe('2026-05-11T14:35:22');
+  });
+
+  it('Deve extrair as comorbidades quando vierem diretamente na raiz do JSON (Exemplo Real)', () => {
+    const mockData = {
+      patientComments: {
+        hypertension: true,
+        smoker: false,
+        glaucoma: false,
+        cataract: true
+      }
+    } as ExtractedDicomData;
+
+    const result = mapDicomToExamForm(mockData);
+    
+    expect(result.comorbidades).toBe('Hipertensão, Catarata');
+  });
+
+  it('Deve extrair as comorbidades quando vierem dentro de "anamnesis" (Exemplo da Issue)', () => {
+    const mockData = {
+      patientComments: {
+        anamnesis: {
+          hypertension: false,
+          smoker: true,
+          glaucoma: true,
+          cataract: false
+        }
+      }
+    } as ExtractedDicomData;
+
+    const result = mapDicomToExamForm(mockData);
+    
+    expect(result.comorbidades).toBe('Fumante, Glaucoma');
+  });
+
+  it('Deve retornar comorbidades como undefined se o JSON vier vazio ou nulo', () => {
+    const mockDataNull = { patientComments: null } as ExtractedDicomData;
+    const mockDataVazio = { patientComments: {} } as ExtractedDicomData;
+
+    expect(mapDicomToExamForm(mockDataNull).comorbidades).toBeUndefined();
+    expect(mapDicomToExamForm(mockDataVazio).comorbidades).toBeUndefined();
+  });
+});

--- a/src/test/utils/dicom/parseDicomFile.test.ts
+++ b/src/test/utils/dicom/parseDicomFile.test.ts
@@ -1,0 +1,76 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { parseDicomFile } from '@/utils/dicom/parseDicomFile';
+import dicomParser from 'dicom-parser';
+
+vi.mock('dicom-parser', () => ({
+  default: {
+    parseDicom: vi.fn(),
+  },
+}));
+
+describe('Utilitário DICOM - parseDicomFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('Deve extrair os metadados corretamente de um arquivo válido', async () => {
+    const mockDataSet = {
+      string: vi.fn((tag: string) => {
+        if (tag === 'x00100020') return 'phelcom_123';
+        if (tag === 'x00104000') return '{"hypertension": true}';
+        if (tag === 'x00100040') return 'M';
+        return '';
+      }),
+    };
+    (dicomParser.parseDicom as any).mockReturnValue(mockDataSet);
+
+    const fakeFile = new File([''], 'exame.dcm', { type: 'application/dicom' });
+    
+    const result = await parseDicomFile(fakeFile);
+
+    expect(result.patientId).toBe('phelcom_123');
+    expect(result.patientComments).toEqual({ hypertension: true });
+    expect(result.patientSex).toBe('M');
+  });
+
+  it('Deve lançar erro se o PatientID não for encontrado', async () => {
+    const mockDataSet = {
+      string: vi.fn((tag: string) => {
+        if (tag === 'x00100020') return undefined;
+        return 'dados_genericos';
+      }),
+    };
+    (dicomParser.parseDicom as any).mockReturnValue(mockDataSet);
+
+    const fakeFile = new File([''], 'exame_sem_id.dcm');
+
+    await expect(parseDicomFile(fakeFile)).rejects.toThrow(
+      'Arquivo DICOM inválido: O identificador do paciente (PatientID) está ausente.'
+    );
+  });
+
+  it('Deve ignorar o erro de JSON se o PatientComments vier corrompido, e retornar null', async () => {
+    const mockSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const mockDataSet = {
+      string: vi.fn((tag: string) => {
+        if (tag === 'x00100020') return 'phelcom_123';
+        if (tag === 'x00104000') return '{ json_invalido: sem_aspas }';
+        return '';
+      }),
+    };
+    (dicomParser.parseDicom as any).mockReturnValue(mockDataSet);
+
+    const fakeFile = new File([''], 'exame_corrompido.dcm');
+    const result = await parseDicomFile(fakeFile);
+
+    expect(result.patientComments).toBeNull();
+    expect(mockSpy).toHaveBeenCalledWith(
+      'O PatientComments não é um JSON válido ou está vazio.',
+      expect.any(Error)
+    );
+
+    mockSpy.mockRestore();
+  });
+});

--- a/src/utils/dicom/dicom.types.ts
+++ b/src/utils/dicom/dicom.types.ts
@@ -1,0 +1,48 @@
+export interface PatientComments {
+  hypertension?: boolean;
+  smoker?: boolean;
+  glaucoma?: boolean;
+  cataract?: boolean;
+
+  anamnesis?: {
+    hypertension?: boolean;
+    smoker?: boolean;
+    glaucoma?: boolean;
+    cataract?: boolean;
+  };
+
+  diopter?: {
+    right?: {
+      spherical?: string;
+      cylindrical?: string;
+      axis?: string;
+    };
+    left?: {
+      spherical?: string;
+      cylindrical?: string;
+      axis?: string;
+    };
+  };
+
+  email?: string;
+}
+
+export interface ExtractedDicomData {
+  patientId: string;
+  patientComments: PatientComments | null;
+  patientSex: string;
+  patientBirthDate: string;
+  pupilDilated: string;
+  imageLaterality: string;
+  manufacturer: string;
+  modelName: string;
+  serialNumber: string;
+  softwareVersions: string;
+  instituionName: string;
+  seriesDescription: string;
+  seriesDate: string;
+  seriesTime: string;
+  seriesNumber: string;
+  modality: string;
+  studyId: string;
+}

--- a/src/utils/dicom/mapDicomToForm.ts
+++ b/src/utils/dicom/mapDicomToForm.ts
@@ -1,0 +1,66 @@
+import type {
+  CreateExamDTO,
+  SexoExame,
+} from '@/features/criacao-exames/types/exam';
+import type { ExtractedDicomData, PatientComments } from './dicom.types';
+
+const mapDicomSex = (dicomSex: string): SexoExame => {
+  if (!dicomSex) return 'OUTRO';
+  
+  const upperSex = dicomSex.toUpperCase();
+  if (upperSex == 'M') return 'MASCULINO';
+  if (upperSex == 'F') return 'FEMININO';
+  return 'OUTRO';
+};
+
+const formatBirthDate = (dateStr: string): string => {
+  if (!dateStr || dateStr.length !== 8) return '';
+  const year = dateStr.substring(0, 4);
+  const month = dateStr.substring(4, 6);
+  const day = dateStr.substring(6, 8);
+
+  return `${day}-${month}-${year}`;
+};
+
+const formatSeriesDate = (dateStr: string): string => {
+  if (!dateStr || dateStr.length !== 8) return '';
+  return `${dateStr.substring(0, 4)}-${dateStr.substring(4, 6)}-${dateStr.substring(6, 8)}`;
+};
+
+const formatDicomTime = (timeStr: string): string => {
+  if (!timeStr || timeStr.length < 6) return '';
+  return `${timeStr.substring(0, 2)}:${timeStr.substring(2, 4)}:${timeStr.substring(4, 6)}`;
+};
+
+const formatarComorbidades = (
+  comments: PatientComments | null
+): string | undefined => {
+  if (!comments) return undefined;
+
+  const dataToRead = comments.anamnesis ? comments.anamnesis : comments;
+
+  const comorbidades: string[] = [];
+
+  if (dataToRead.hypertension) comorbidades.push('Hipertensão');
+  if (dataToRead.smoker) comorbidades.push('Fumante');
+  if (dataToRead.glaucoma) comorbidades.push('Glaucoma');
+  if (dataToRead.cataract) comorbidades.push('Catarata');
+
+  return comorbidades.length > 0 ? comorbidades.join(', ') : undefined;
+};
+
+export const mapDicomToExamForm = (
+  dicomData: ExtractedDicomData
+): Partial<CreateExamDTO> => {
+  const dataFormatada = formatSeriesDate(dicomData.seriesDate);
+  const horaFormatada = formatDicomTime(dicomData.seriesTime);
+  const dtHora =
+    dataFormatada && horaFormatada ? `${dataFormatada}T${horaFormatada}` : '';
+
+  return {
+    sexo: mapDicomSex(dicomData.patientSex),
+    dtNascimento: formatBirthDate(dicomData.patientBirthDate),
+    dtHora: dtHora,
+    comorbidades: formatarComorbidades(dicomData.patientComments),
+  };
+};

--- a/src/utils/dicom/parseDicomFile.ts
+++ b/src/utils/dicom/parseDicomFile.ts
@@ -1,0 +1,69 @@
+import dicomParser from 'dicom-parser';
+import type { ExtractedDicomData, PatientComments } from './dicom.types';
+
+export const parseDicomFile = async (
+  file: File
+): Promise<ExtractedDicomData> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = (event) => {
+      try {
+        const arrayBuffer = event.target?.result as ArrayBuffer;
+        const byteArray = new Uint8Array(arrayBuffer);
+        const dataSet = dicomParser.parseDicom(byteArray);
+        const getString = (tag: string) => dataSet.string(tag) || '';
+
+        const patientCommentsRaw = getString('x00104000');
+        let patientCommentsJSON: PatientComments | null = null;
+
+        if (patientCommentsRaw) {
+          try {
+            patientCommentsJSON = JSON.parse(patientCommentsRaw);
+          } catch (error) {
+            console.warn(
+              'O PatientComments não é um JSON válido ou está vazio.',
+              error
+            );
+          }
+        }
+
+        const extractedData: ExtractedDicomData = {
+          patientId: getString('x00100020'),
+          patientComments: patientCommentsJSON,
+          patientSex: getString('x00100040'),
+          patientBirthDate: getString('x00100030'),
+          pupilDilated: getString('x0022000d'),
+          imageLaterality: getString('x00200062'),
+          manufacturer: getString('x00080070'),
+          modelName: getString('x00081090'),
+          serialNumber: getString('x00181000'),
+          softwareVersions: getString('x00181020'),
+          instituionName: getString('x00080080'),
+          seriesDescription: getString('x0008103e'),
+          seriesDate: getString('x00080021'),
+          seriesTime: getString('x00080031'),
+          seriesNumber: getString('x00200011'),
+          modality: getString('x00080060'),
+          studyId: getString('x00200010'),
+        };
+
+        if (!extractedData.patientId) {
+          throw new Error(
+            'Arquivo DICOM inválido: O identificador do paciente (PatientID) está ausente.'
+          );
+        }
+
+        resolve(extractedData);
+      } catch (error) {
+        reject(error);
+      }
+    };
+
+    reader.onerror = () => {
+      reject(new Error('Falha na leitura do arquivo pelo navegador.'));
+    };
+
+    reader.readAsArrayBuffer(file);
+  });
+};


### PR DESCRIPTION
## Descrição
Adicionei a extração dos dados que vem embutidos nas fotos do tipo DICOM, fiz o mapeamento dos dados principais para facilitar no preenchimento das informações do exame e realizei testes unitários.

## Issue
#38 

## Principais Implementações
- Adição da biblioteca `dicom-parser` para permitir a leitura binária dos arquivos `.dcm` no frontend.
- Criação das interfaces `ExtractedDicomData` e `PatientComments` para espelhar as tags DICOM exigidas pela issue e garantir a segurança de tipos (Type Safety).
- Implementação da função que utiliza `FileReader` e os códigos hexadecimais do DICOM para extrair metadados como PatientID, Sexo, e conversão segura do JSON de comorbidades (com tratamento de exceções caso o JSON venha corrompido).
- Criação da lógica de transformação (`mapDicomToExamForm`) que adapta os dados brutos para o formato `Partial<CreateExamDTO>` consumido pelo formulário, incluindo conversão de datas para `DD-MM-YYYY`, mapeamento de sexo (M/F/O -> MASCULINO/FEMININO/OUTRO) e formatação da string de comorbidades.

## Tipos de Mudanças
 - [ ] Bug fix (alteração que corrige uma issue e não altera funcionalidades já existentes);
 - [X] Nova feature (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes);
 - [ ] Alteração disruptiva (Breaking change) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes);
 - [ ] Documentação