### PR TITLE
feat: adiciona texto template ao iniciar a criacao do laudo

### DIFF
--- a/src/features/historico-exames/components/CardLaudo.tsx
+++ b/src/features/historico-exames/components/CardLaudo.tsx
@@ -18,6 +18,7 @@ import {
 } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import '@/features/historico-exames/styles/editor-style.css';
+import { LAUDO_TEMPLATE_HTML } from '@/utils/templates/laudo_template';
 
 export type LaudoValue = {
   json: JSONContent | null;
@@ -50,7 +51,12 @@ export function CardLaudo({
   onChange,
   onSubmit,
 }: CardLaudoProps) {
-  const initialValue = useMemo(() => value ?? EMPTY_VALUE, [value]);
+  const initialValue = useMemo(() => {
+    if (mode === 'edit') return value ?? EMPTY_VALUE;
+    if (value?.json || value?.html) return value;
+    return { ...EMPTY_VALUE, html: LAUDO_TEMPLATE_HTML };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   const lastSyncedContentRef = useRef<string | null>(null);
 
   const [resultadoIaValido, setResultadoIaValido] = useState<boolean | null>(
@@ -60,14 +66,8 @@ export function CardLaudo({
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
-        bulletList: {
-          keepMarks: true,
-          keepAttributes: false,
-        },
-        orderedList: {
-          keepMarks: true,
-          keepAttributes: false,
-        },
+        bulletList: { keepMarks: true, keepAttributes: false },
+        orderedList: { keepMarks: true, keepAttributes: false },
       }),
     ],
     content: initialValue.json ?? initialValue.html ?? '<p></p>',
@@ -112,37 +112,34 @@ export function CardLaudo({
   useEffect(() => {
     if (!editor) return;
 
+    // No modo create sem value externo, não sobrescreve o template
+    if (mode === 'create' && !value?.json && !value?.html) return;
+
     const incomingSerialized = value?.json
       ? JSON.stringify(value.json)
       : (value?.html ?? '<p></p>');
 
-    if (lastSyncedContentRef.current === incomingSerialized) {
-      return;
-    }
+    if (lastSyncedContentRef.current === incomingSerialized) return;
 
     if (value?.json) {
       const current = JSON.stringify(editor.getJSON());
-
       if (current !== incomingSerialized) {
         editor.commands.setContent(value.json, { emitUpdate: false });
       }
-
       lastSyncedContentRef.current = incomingSerialized;
       return;
     }
 
     if (typeof value?.html === 'string') {
       const currentHtml = editor.getHTML();
-
       if (currentHtml !== value.html) {
         editor.commands.setContent(value.html || '<p></p>', {
           emitUpdate: false,
         });
       }
-
       lastSyncedContentRef.current = incomingSerialized;
     }
-  }, [editor, value?.json, value?.html]);
+  }, [editor, value?.json, value?.html, mode]);
 
   const getCurrentValue = (
     nextResultadoIaValido = resultadoIaValido

--- a/src/test/features/historico-exames/components/CardLaudo.test.tsx
+++ b/src/test/features/historico-exames/components/CardLaudo.test.tsx
@@ -4,14 +4,41 @@ import { describe, it, expect } from 'vitest';
 import { CardLaudo } from '../../../../features/historico-exames/components/CardLaudo';
 
 describe('CardLaudo', () => {
-  it('renders action buttons and placeholder', async () => {
+  it('renders action buttons', () => {
     render(<CardLaudo />);
 
-    // Buttons
     expect(screen.getByText('Correto')).toBeDefined();
     expect(screen.getByText('Incorreto')).toBeDefined();
+  });
 
-    // Placeholder text should be present in the DOM
-    expect(screen.getByText('Digite o laudo do especialista...')).toBeDefined();
+  it('renders editor container in create mode', () => {
+    const { container } = render(<CardLaudo />);
+
+    // Verifica que o container do editor foi montado
+    const editorEl = container.querySelector('.tiptap-content');
+    expect(editorEl).not.toBeNull();
+  });
+
+  it('submit button is disabled when there is no content or ai evaluation', () => {
+    render(<CardLaudo />);
+
+    const submitBtn = screen.getByText('Submeter laudo');
+    expect(submitBtn.closest('button')?.disabled).toBe(true);
+  });
+
+  it('renders save button in edit mode', () => {
+    render(
+      <CardLaudo
+        mode="edit"
+        value={{
+          json: null,
+          html: '<p>Laudo customizado</p>',
+          texto: 'Laudo customizado',
+          resultadoIaValido: null,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Salvar alterações')).toBeDefined();
   });
 });

--- a/src/utils/templates/laudo_template.ts
+++ b/src/utils/templates/laudo_template.ts
@@ -1,0 +1,13 @@
+export const LAUDO_TEMPLATE_HTML = `
+<p><strong>Olho Direito</strong></p>
+<p><strong>Disco Óptico:</strong> Disco óptico com dimensões regulares, normocorado, com bordas regulares, rima neural e camada de fibras normais. Escavação Horizontal de 0,3 e escavação vertical de 0,3. Ausência de atrofia peridiscal, hemorragia de disco e outras anomalias.</p>
+<p><strong>Vascularização:</strong> Vasos com calibre, cruzamento arteríolo-venular, reflexo dorsal e tortuosidade normais. Ausência de alterações microvasculares.</p>
+<p><strong>Retina:</strong> Retina aplicada em região do pólo posterior, com brilho e coloração foveal habituais. Ausência de lesões.</p>
+<p><strong>Conclusão:</strong> Exame normal</p>
+<p></p>
+<p><strong>Olho Esquerdo</strong></p>
+<p><strong>Disco Óptico:</strong> Disco óptico com dimensões regulares, normocorado, com bordas regulares, rima neural e camada de fibras normais. Escavação Horizontal de 0,3 e escavação vertical de 0,3. Ausência de atrofia peridiscal, hemorragia de disco e outras anomalias.</p>
+<p><strong>Vascularização:</strong> Vasos com calibre, cruzamento arteríolo-venular, reflexo dorsal e tortuosidade normais. Ausência de alterações microvasculares.</p>
+<p><strong>Retina:</strong> Retina aplicada em região do pólo posterior, com brilho e coloração foveal habituais. Ausência de lesões.</p>
+<p><strong>Conclusão:</strong> Exame normal</p>
+`;


### PR DESCRIPTION
## Descrição
Adiciona texto modelo no laudo de especialista.
Esse texto aparece apenas antes de o médico especialista cadastrar um laudo pela primeira vez. No modo de edição, o laudo salvo no banco de dados é carregado normalmente.

## Issue
[[#109](https://app.zenhub.com/workspaces/20261-retinascan-69bd9cee544e2d00306abb69/issues/gh/fga-eps-mds/2026-1-retinascan-doc/109)](https://app.zenhub.com/workspaces/20261-retinascan-69bd9cee544e2d00306abb69/issues/gh/fga-eps-mds/2026-1-retinascan-doc/109)

## Principais Implementações
- Criação do arquivo `src/utils/templates/laudo_template.ts` com o template HTML do laudo padrão definido pelo Dr. Thiago, contendo estrutura para Olho Direito e Olho Esquerdo (Disco Óptico, Vascularização, Retina e Conclusão)
- No componente `CardLaudo`, o `initialValue` agora injeta o template quando `mode === 'create'` e nenhum `value` externo é fornecido
- Adicionado guard no `useEffect` de sincronização de conteúdo para impedir que o template seja sobrescrito por um `value` vazio no modo criação

## Tipos de Mudanças
- [ ] Bug fix (alteração que corrige uma issue e não altera funcionalidades já existentes)
- [x] Nova feature (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (Breaking change) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)
- [ ] Documentação