### PR TITLE
fix: mapeia corretamente o json do dicom para os checkboxes de comorbidades

### DIFF
--- a/src/test/utils/dicom/mapDicomToForm.test.ts
+++ b/src/test/utils/dicom/mapDicomToForm.test.ts
@@ -3,14 +3,13 @@ import { mapDicomToExamForm } from '@/utils/dicom/mapDicomToForm';
 import type { ExtractedDicomData } from '@/utils/dicom/dicom.types';
 
 describe('Utilitário DICOM - mapDicomToExamForm', () => {
-  
   it('Deve formatar os dados básicos corretamente (Datas, Hora e Sexo)', () => {
     const mockData = {
       patientSex: 'M',
       patientBirthDate: '19980521',
       seriesDate: '20260511',
-      seriesTime: '143522', 
-      patientComments: null
+      seriesTime: '143522',
+      patientComments: null,
     } as ExtractedDicomData;
 
     const result = mapDicomToExamForm(mockData);
@@ -26,30 +25,46 @@ describe('Utilitário DICOM - mapDicomToExamForm', () => {
         hypertension: true,
         smoker: false,
         glaucoma: false,
-        cataract: true
-      }
+        cataract: true,
+      },
     } as ExtractedDicomData;
 
     const result = mapDicomToExamForm(mockData);
-    
-    expect(result.comorbidades).toBe('Hipertensão, Catarata');
+
+    expect(result.comorbidades).toEqual(
+      expect.objectContaining({
+        hipertensao: true,
+        catarata: true,
+        glaucoma: false,
+        outrasComorbidades: false,
+        outrasComorbidadesDescricao: undefined,
+      })
+    );
   });
 
-  it('Deve extrair as comorbidades quando vierem dentro de "anamnesis" (Exemplo da Issue)', () => {
+  it('Deve extrair as comorbidades e mapear "smoker" para "Outras" quando vierem dentro de "anamnesis"', () => {
     const mockData = {
       patientComments: {
         anamnesis: {
           hypertension: false,
           smoker: true,
           glaucoma: true,
-          cataract: false
-        }
-      }
+          cataract: false,
+        },
+      },
     } as ExtractedDicomData;
 
     const result = mapDicomToExamForm(mockData);
-    
-    expect(result.comorbidades).toBe('Fumante, Glaucoma');
+
+    expect(result.comorbidades).toEqual(
+      expect.objectContaining({
+        hipertensao: false,
+        glaucoma: true,
+        catarata: false,
+        outrasComorbidades: true,
+        outrasComorbidadesDescricao: 'Fumante',
+      })
+    );
   });
 
   it('Deve retornar comorbidades como undefined se o JSON vier vazio ou nulo', () => {

--- a/src/test/utils/dicom/parseDicomFile.test.ts
+++ b/src/test/utils/dicom/parseDicomFile.test.ts
@@ -38,7 +38,7 @@ describe('Utilitário DICOM - parseDicomFile', () => {
     const mockDataSet = {
       string: vi.fn((tag: string) => {
         if (tag === 'x00100020') return undefined;
-        return '{}'; // <-- Retorna um JSON válido e vazio para não quebrar o parse
+        return '{}';
       }),
     };
     (dicomParser.parseDicom as any).mockReturnValue(mockDataSet);

--- a/src/test/utils/dicom/parseDicomFile.test.ts
+++ b/src/test/utils/dicom/parseDicomFile.test.ts
@@ -34,11 +34,11 @@ describe('Utilitário DICOM - parseDicomFile', () => {
     expect(result.patientSex).toBe('M');
   });
 
-  it('Deve lançar erro se o PatientID não for encontrado', async () => {
+ it('Deve lançar erro se o PatientID não for encontrado', async () => {
     const mockDataSet = {
       string: vi.fn((tag: string) => {
         if (tag === 'x00100020') return undefined;
-        return 'dados_genericos';
+        return '{}'; // <-- Retorna um JSON válido e vazio para não quebrar o parse
       }),
     };
     (dicomParser.parseDicom as any).mockReturnValue(mockDataSet);

--- a/src/utils/dicom/mapDicomToForm.ts
+++ b/src/utils/dicom/mapDicomToForm.ts
@@ -1,4 +1,5 @@
 import type {
+  ComorbidadesDTO,
   CreateExamDTO,
   SexoExame,
 } from '@/features/criacao-exames/types/exam';
@@ -6,7 +7,7 @@ import type { ExtractedDicomData, PatientComments } from './dicom.types';
 
 const mapDicomSex = (dicomSex: string): SexoExame => {
   if (!dicomSex) return 'OUTRO';
-  
+
   const upperSex = dicomSex.toUpperCase();
   if (upperSex == 'M') return 'MASCULINO';
   if (upperSex == 'F') return 'FEMININO';
@@ -34,19 +35,34 @@ const formatDicomTime = (timeStr: string): string => {
 
 const formatarComorbidades = (
   comments: PatientComments | null
-): string | undefined => {
+): ComorbidadesDTO | undefined => {
   if (!comments) return undefined;
 
   const dataToRead = comments.anamnesis ? comments.anamnesis : comments;
 
-  const comorbidades: string[] = [];
+  const hasData =
+    dataToRead.hypertension ||
+    dataToRead.smoker ||
+    dataToRead.glaucoma ||
+    dataToRead.cataract;
 
-  if (dataToRead.hypertension) comorbidades.push('Hipertensão');
-  if (dataToRead.smoker) comorbidades.push('Fumante');
-  if (dataToRead.glaucoma) comorbidades.push('Glaucoma');
-  if (dataToRead.cataract) comorbidades.push('Catarata');
+  if (!hasData) return undefined;
 
-  return comorbidades.length > 0 ? comorbidades.join(', ') : undefined;
+  return {
+    diabetes: false,
+    diabetesUsoInsulina: false,
+    diabetesControlado: false,
+    hipertensao: !!dataToRead.hypertension,
+    hipertensaoControlada: false,
+    altaMiopia: false,
+    glaucoma: !!dataToRead.glaucoma,
+    usoHidroxicloroquina: false,
+    uveite: false,
+    catarata: !!dataToRead.cataract,
+    outrasComorbidades: !!dataToRead.smoker,
+    outrasComorbidadesDescricao: dataToRead.smoker ? 'Fumante' : undefined,
+    qualidadeTecnicaDificuldade: false,
+  };
 };
 
 export const mapDicomToExamForm = (


### PR DESCRIPTION
## Descrição
Este PR refatora a extração e o mapeamento das comorbidades contidas nos metadados de arquivos DICOM para o frontend. Anteriormente, as informações (como hipertensão, catarata, glaucoma e se o paciente é fumante) eram concatenadas e retornadas como uma única string. A função `formatarComorbidades` foi atualizada para popular e retornar o objeto `ComorbidadesDTO` tipado corretamente.

## Issue
Closes #73 

## Principais Implementações
* A função `formatarComorbidades` agora retorna um `ComorbidadesDTO` (ou `undefined` se não houver dados), preenchendo as chaves booleanas mapeadas diretamente da anamnese do DICOM.
* A propriedade DICOM smoker passou a acionar explicitamente a flag `outrasComorbidades`: `true` no DTO, definindo o campo `outrasComorbidadesDescricao` como 'Fumante'.
* Os testes no `mapDicomToExamForm.spec.ts` foram reescritos para validar a estrutura do novo objeto `ComorbidadesDTO` em vez de inspecionar strings.
* 

## Tipos de Mudanças
 - [X] Bug fix (alteração que corrige uma issue e não altera funcionalidades já existentes);
 - [ ] Nova feature (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes);
 - [ ] Alteração disruptiva (Breaking change) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes);
 - [ ] Documentação